### PR TITLE
feat: add option to train on specific train chars

### DIFF
--- a/model/src/model/phonikud_model.py
+++ b/model/src/model/phonikud_model.py
@@ -21,16 +21,6 @@ NIKUD_HASER = "\u05af"  # not in use but dicta has it
 ENHANCED_NIKUD = HATAMA_CHAR + VOCAL_SHVA_CHAR + PREFIX_CHAR + NIKUD_HASER
 
 
-def get_char_name(char: str) -> str:
-    """Get clean character name without Unicode symbols"""
-    names = {
-        HATAMA_CHAR: "HATAMA",
-        VOCAL_SHVA_CHAR: "VOCAL_SHVA",
-        PREFIX_CHAR: "PREFIX",
-    }
-    return names.get(char, char)
-
-
 def remove_enhanced_nikud(text: str):
     return remove_nikud(text, additional=ENHANCED_NIKUD)
 
@@ -104,10 +94,10 @@ class PhonikudModel(BertForDiacritization):
                 idx = char_to_idx[char]
                 final_layer.weight[idx].requires_grad = True
                 final_layer.bias[idx].requires_grad = True
-                from src.train.utils import get_char_name
+                from src.train.utils import get_train_char_name
 
                 print(
-                    f"🔓 Unfrozen parameters for {get_char_name(char)} (channel {idx})"
+                    f"🔓 Unfrozen parameters for {get_train_char_name(char)} (channel {idx})"
                 )
 
     def forward(self, x):

--- a/model/src/train/config.py
+++ b/model/src/train/config.py
@@ -1,6 +1,7 @@
 from tap import Tap
-from typing import Literal
+from typing import Literal, List
 from pathlib import Path
+from src.model.phonikud_model import HATAMA_CHAR, VOCAL_SHVA_CHAR, PREFIX_CHAR
 
 BASE_PATH = Path(__file__).parent / "../.."
 
@@ -61,6 +62,9 @@ class TrainArgs(Tap):
 
     wandb_mode: str = "offline"
     "Wandb mode: 'online', 'offline', or 'disabled' (default: offline for local use)"
+
+    train_chars: List[str] = [HATAMA_CHAR, VOCAL_SHVA_CHAR, PREFIX_CHAR]
+    "Characters to train on. Example: ['֫'] for hatama only. Tip: modify directly in config.py since diacritics are hard to pass via CLI"
 
 
 def get_opts():

--- a/model/src/train/main.py
+++ b/model/src/train/main.py
@@ -29,6 +29,7 @@ def main():
 
     model.to(args.device)  # type: ignore
     model.freeze_base_model()
+    model.freeze_specific_chars(args.train_chars)
 
     tokenizer = AutoTokenizer.from_pretrained(
         args.model_checkpoint, trust_remote_code=True

--- a/model/src/train/train_loop.py
+++ b/model/src/train/train_loop.py
@@ -14,7 +14,6 @@ import wandb
 from src.train.utils import (
     calculate_train_batch_metrics,
     save_model,
-    get_char_mask,
     get_train_char_name,
 )
 
@@ -64,9 +63,7 @@ def train_model(
     best_wer = float("inf")  # Track best WER
     early_stop_counter = 0
 
-    # Setup character-specific training
-    char_mask = get_char_mask(args.train_chars).to(args.device)
-
+    # Print character training info
     if len(args.train_chars) == 3:
         print("🎯 Training on all characters")
     else:
@@ -95,11 +92,6 @@ def train_model(
 
             output: MenakedLogitsOutput = model(inputs)
             logits: torch.Tensor = output.additional_logits
-
-            # Apply selective training mask
-            if len(args.train_chars) < 3:  # Only mask if not training all chars
-                logits = logits * char_mask.float()
-                targets = targets * char_mask.float()
 
             loss = criterion(logits, targets.float())
 

--- a/model/src/train/utils.py
+++ b/model/src/train/utils.py
@@ -402,23 +402,6 @@ def save_model(model: PhonikudModel, tokenizer: BertTokenizerFast, dst_path: str
         json.dump(config, f, indent=4)
 
 
-def get_char_mask(chars_to_train: List[str]) -> torch.Tensor:
-    """Returns boolean mask for [hatama, vocal_shva, prefix] channels"""
-    if not chars_to_train:  # Empty list = train all
-        return torch.ones(3, dtype=torch.bool)
-
-    # Map characters to channel indices
-    mask = torch.zeros(3, dtype=torch.bool)
-    if HATAMA_CHAR in chars_to_train:
-        mask[0] = True  # hatama
-    if VOCAL_SHVA_CHAR in chars_to_train:
-        mask[1] = True  # vocal_shva
-    if PREFIX_CHAR in chars_to_train:
-        mask[2] = True  # prefix
-
-    return mask
-
-
 def get_train_char_name(char: str) -> str:
     """Get readable name for a single character"""
     names = {

--- a/model/src/train/utils.py
+++ b/model/src/train/utils.py
@@ -15,11 +15,11 @@ import wandb
 import jiwer
 import random
 from torch.utils.tensorboard import SummaryWriter
-from typing import Union
 from transformers import BertTokenizerFast
 from model.src.model.phonikud_model import ModelPredictions, MenakedLogitsOutput
 from src.train.data import Batch
 import shutil
+from src.model.phonikud_model import HATAMA_CHAR, VOCAL_SHVA_CHAR, PREFIX_CHAR
 
 
 @dataclass
@@ -400,3 +400,30 @@ def save_model(model: PhonikudModel, tokenizer: BertTokenizerFast, dst_path: str
 
     with open(model_config_file, "w") as f:
         json.dump(config, f, indent=4)
+
+
+def get_char_mask(chars_to_train: List[str]) -> torch.Tensor:
+    """Returns boolean mask for [hatama, vocal_shva, prefix] channels"""
+    if not chars_to_train:  # Empty list = train all
+        return torch.ones(3, dtype=torch.bool)
+
+    # Map characters to channel indices
+    mask = torch.zeros(3, dtype=torch.bool)
+    if HATAMA_CHAR in chars_to_train:
+        mask[0] = True  # hatama
+    if VOCAL_SHVA_CHAR in chars_to_train:
+        mask[1] = True  # vocal_shva
+    if PREFIX_CHAR in chars_to_train:
+        mask[2] = True  # prefix
+
+    return mask
+
+
+def get_train_char_name(char: str) -> str:
+    """Get readable name for a single character"""
+    names = {
+        HATAMA_CHAR: "hatama(֫)",
+        VOCAL_SHVA_CHAR: "vocal_shva(ֽ)",
+        PREFIX_CHAR: "prefix(|)",
+    }
+    return names.get(char, char)


### PR DESCRIPTION
add option to train on specific train chars by configuring them in config.py
# Character-Specific Training via Parameter Freezing

## How It Works

Adds ability to train only on specific diacritics (hatama, vocal_shva, prefix) by freezing MLP parameters.

**Freezing Mechanism:**

1. **Freeze entire MLP** - all parameters get `requires_grad = False`
2. **Unfreeze specific outputs** - only selected character channels get `requires_grad = True`

```python
def freeze_specific_chars(self, chars_to_train: List[str]):
    # Step 1: Freeze entire MLP (including 1024→256 layer)
    for param in self.mlp.parameters():
        param.requires_grad = False

    # Step 2: Unfreeze only specific output channels
    final_layer = self.mlp[-1]  # nn.Linear(256, 3)
    for char in chars_to_train:
        idx = char_to_idx[char]
        final_layer.weight[idx].requires_grad = True
        final_layer.bias[idx].requires_grad = True
```

**Result:** For HATAMA-only training, only `weight[0]` and `bias[0]` are trainable. The penultimate layer (1024→256) stays frozen, ensuring clean parameter isolation.

**Usage:** Set `train_chars = [HATAMA_CHAR]` in config.py → run training normally.

Perfect for datasets with fixes only for specific characters! 🎯
